### PR TITLE
update eslint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -112,16 +112,14 @@
         "no-useless-constructor": "off",
         "@typescript-eslint/no-useless-constructor": "warn",
         "@typescript-eslint/prefer-literal-enum-member": "error"
-      },
-      "overrides": [
-        {
-          "files": ["packages/**"],
-          "rules": {
-            "jsdoc/no-types": "error",
-            "jsdoc/no-undefined-types": "error"
-          }
-        }
-      ]
+      }
+    },
+    {
+      "files": ["packages/**"],
+      "rules": {
+        "jsdoc/no-types": "error",
+        "jsdoc/no-undefined-types": "error"
+      }
     },
     {
       "files": [


### PR DESCRIPTION
### Fixing a bug
- I checked the eslint config and found that override property is not supposed to be inside another override property.
- I couldn't checked the entire file as it was a big config file, but I guess it was supposed to be a part of global overrides array of eslint.
